### PR TITLE
Opened up BaseCurrency for embedding

### DIFF
--- a/entities/currency.go
+++ b/entities/currency.go
@@ -12,8 +12,8 @@ type Currency interface {
 	Wrapped() *Token
 }
 
-// baseCurrency is an abstract struct, do not use it directly
-type baseCurrency struct {
+// BaseCurrency is an abstract struct, do not use it directly
+type BaseCurrency struct {
 	currency Currency
 	isNative bool   // Returns whether the currency is native to the chain and must be wrapped (e.g. Ether)
 	isToken  bool   // Returns whether the currency is a token that is usable in Uniswap without wrapping
@@ -23,35 +23,35 @@ type baseCurrency struct {
 	name     string // The name of the currency, i.e. a descriptive textual non-unique identifier
 }
 
-func (c *baseCurrency) IsNative() bool {
+func (c *BaseCurrency) IsNative() bool {
 	return c.isNative
 }
 
-func (c *baseCurrency) IsToken() bool {
+func (c *BaseCurrency) IsToken() bool {
 	return c.isToken
 }
 
-func (c *baseCurrency) ChainId() uint {
+func (c *BaseCurrency) ChainId() uint {
 	return c.chainId
 }
 
-func (c *baseCurrency) Decimals() uint {
+func (c *BaseCurrency) Decimals() uint {
 	return c.decimals
 }
 
-func (c *baseCurrency) Symbol() string {
+func (c *BaseCurrency) Symbol() string {
 	return c.symbol
 }
 
-func (c *baseCurrency) Name() string {
+func (c *BaseCurrency) Name() string {
 	return c.name
 }
 
 // Equal returns whether the currency is equal to the other currency
-func (c *baseCurrency) Equal(other Currency) bool {
+func (c *BaseCurrency) Equal(other Currency) bool {
 	panic("Equal method has to be overridden")
 }
 
-func (c *baseCurrency) Wrapped() *Token {
+func (c *BaseCurrency) Wrapped() *Token {
 	panic("Wrapped method has to be overridden")
 }

--- a/entities/ether.go
+++ b/entities/ether.go
@@ -2,12 +2,12 @@ package entities
 
 // Ether is the main usage of a 'native' currency, i.e. for Ethereum mainnet and all testnets
 type Ether struct {
-	*baseCurrency
+	*BaseCurrency
 }
 
 func EtherOnChain(chainId uint) *Ether {
 	ether := &Ether{
-		baseCurrency: &baseCurrency{
+		BaseCurrency: &BaseCurrency{
 			isNative: true,
 			isToken:  false,
 			chainId:  chainId,
@@ -16,7 +16,7 @@ func EtherOnChain(chainId uint) *Ether {
 			name:     "Ether",
 		},
 	}
-	ether.baseCurrency.currency = ether
+	ether.BaseCurrency.currency = ether
 	return ether
 }
 

--- a/entities/token.go
+++ b/entities/token.go
@@ -14,7 +14,7 @@ var (
 
 // Token represents an ERC20 token with a unique address and some metadata.
 type Token struct {
-	*baseCurrency
+	*BaseCurrency
 	Address common.Address // The contract address on the chain on which this token lives
 }
 
@@ -24,7 +24,7 @@ func NewToken(chainID uint, address common.Address, decimals uint, symbol string
 		panic("Token currency decimals must be less than 255")
 	}
 	token := &Token{
-		baseCurrency: &baseCurrency{
+		BaseCurrency: &BaseCurrency{
 			isNative: false,
 			isToken:  true,
 			chainId:  chainID,
@@ -34,7 +34,7 @@ func NewToken(chainID uint, address common.Address, decimals uint, symbol string
 		},
 		Address: address,
 	}
-	token.baseCurrency.currency = token
+	token.BaseCurrency.currency = token
 	return token
 }
 


### PR DESCRIPTION
This is for chains where Ether is not a native token (e.g. Avalanche) and we need to implement another one.